### PR TITLE
[1.x] add type hint to `chromeDriverSlug()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,3 @@
 /coverage/*
 /.phpunit.cache/*
 /.phpunit.result.cache
-
-# IDE
-/.idea
-/.nova
-/.vscode
-/.zed

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@
 /coverage/*
 /.phpunit.cache/*
 /.phpunit.result.cache
+
+# IDE
+/.idea
+/.nova
+/.vscode
+/.zed

--- a/src/OperatingSystem.php
+++ b/src/OperatingSystem.php
@@ -87,10 +87,8 @@ class OperatingSystem
 
     /**
      * Resolve ChromeDriver slug.
-     *
-     * @param  string|null  $version
      */
-    public static function chromeDriverSlug(string $operatingSystem, $version = null): string
+    public static function chromeDriverSlug(string $operatingSystem, ?string $version = null): string
     {
         $slug = static::$platforms[$operatingSystem]['slug'] ?? null;
 


### PR DESCRIPTION
I know the project is fairly new, so not sure if you're accepting PR's yet, but wanted to help and noticed the below:


Added the `?string` type to the $version param.  This is used in other classes, so I presume it's safe enough. Tests pass with it too.

The docblock was removed via pint,  otherwise it was failing CI tests locally. So not sure if needed or not?

Added some IDE bits to the .gitignore as PHPstorm created plenty of .idea files - thought it would be good.

Feel free to let me know if you want any changes 🫡 

Thanks



